### PR TITLE
Player Rotation after Flight Ends Fix

### DIFF
--- a/Players/Flight/DBTPlayer.Flight.cs
+++ b/Players/Flight/DBTPlayer.Flight.cs
@@ -106,7 +106,9 @@ namespace DBT.Players
         internal void OnPlayerFlightStateChanged(bool state)
         {
             if (!state)
-                player.fullRotation = MathHelper.Lerp(player.fullRotation, 0, 0.1f);
+            {
+                player.fullRotation = 0;
+            }
         }
 
 


### PR DESCRIPTION
- player now resets back to normal rotation after Flight Ends
- It was using originally Lerp that would have to be called over multiple frames (not just one)